### PR TITLE
fixed invalid yml

### DIFF
--- a/config/syringe.yml
+++ b/config/syringe.yml
@@ -9,15 +9,15 @@ services:
     socketFactory:
         class: Silktide\QueueBall\ZeroMq\SocketFactory
         arguments:
-            - @zmqContext
-            - %sendTimeout%
+            - "@zmqContext"
+            - "%sendTimeout%"
 
     zeroMqQueue:
         class: Silktide\QueueBall\ZeroMq\Queue
         arguments:
-            - @socketFactory
-            - @silktide_queueball.messageFactory
-            - %queueId%
+            - "@socketFactory"
+            - "@silktide_queueball.messageFactory"
+            - "%queueId%"
 
     silktide_queueball.defaultQueue:
-        aliasOf: @zeroMqQueue
+        aliasOf: "@zeroMqQueue"


### PR DESCRIPTION
As per https://github.com/symfony/symfony/issues/16234 (and in more detail http://www.yaml.org/spec/1.2/spec.html#id2774157) using @ at the start of unquoted strings isn't valid yaml.

As of version 2.8 it throws warnings in symfony/yaml and throws parse errors in 3.0.

I've moved the values to being quoted instead (and thus spec compliant)
